### PR TITLE
chore: Migrate python-documentai synth.py from microgenerator docker image to bazel

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -20,12 +20,18 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICMicrogenerator()
+gapic = gcp.GAPICBazel()
 common = gcp.CommonTemplates()
 
 # ----------------------------------------------------------------------------
 # Generate document AI GAPIC layer
 # ----------------------------------------------------------------------------
+library = gapic.py_library(
+    service="documentai",
+    version="v1beta2",
+    bazel_target="//google/cloud/documentai/v1beta2:documentai-v1beta2-py",
+)
+
 library = gapic.py_library("documentai", "v1beta2")
 
 excludes = ["README.rst", "nox.py", "docs/index.rst", "setup.py"]


### PR DESCRIPTION
Notice the corresponding changes in documentai [BUILD.bazel](https://github.com/googleapis/googleapis/blob/master/google/cloud/documentai/v1beta2/BUILD.bazel#L150) which invokes gapic-generator-python rules implementation instead of the monolith.
