### PR TITLE
fix: adds comment with explicit hostname change

### DIFF
--- a/samples/snippets/batch_process_documents_sample_v1beta3.py
+++ b/samples/snippets/batch_process_documents_sample_v1beta3.py
@@ -38,6 +38,10 @@ def batch_process_documents(
     timeout: int = 300,
 ):
 
+    # You must set the api_endpoint if you use a location other than 'us', e.g.:
+    # client = documentai.DocumentProcessorServiceClient(
+    #     {"api_endpoint": "eu-documentai.googleapis.com"}
+    # )
     client = documentai.DocumentProcessorServiceClient()
 
     destination_uri = f"{gcs_output_uri}/{gcs_output_uri_prefix}/"

--- a/samples/snippets/batch_process_documents_sample_v1beta3.py
+++ b/samples/snippets/batch_process_documents_sample_v1beta3.py
@@ -43,7 +43,7 @@ def batch_process_documents(
     if location == "eu":
         opts = {"api_endpoint": "eu-documentai.googleapis.com"}
 
-    client = documentai.DocumentProcessorServiceClient(opts)
+    client = documentai.DocumentProcessorServiceClient(client_options=opts)
 
     destination_uri = f"{gcs_output_uri}/{gcs_output_uri_prefix}/"
 

--- a/samples/snippets/batch_process_documents_sample_v1beta3.py
+++ b/samples/snippets/batch_process_documents_sample_v1beta3.py
@@ -39,10 +39,11 @@ def batch_process_documents(
 ):
 
     # You must set the api_endpoint if you use a location other than 'us', e.g.:
-    # client = documentai.DocumentProcessorServiceClient(
-    #     {"api_endpoint": "eu-documentai.googleapis.com"}
-    # )
-    client = documentai.DocumentProcessorServiceClient()
+    opts = {}
+    if location == 'eu':
+        opts = {"api_endpoint": "eu-documentai.googleapis.com"}
+
+    client = documentai.DocumentProcessorServiceClient(opts)
 
     destination_uri = f"{gcs_output_uri}/{gcs_output_uri_prefix}/"
 

--- a/samples/snippets/batch_process_documents_sample_v1beta3.py
+++ b/samples/snippets/batch_process_documents_sample_v1beta3.py
@@ -40,7 +40,7 @@ def batch_process_documents(
 
     # You must set the api_endpoint if you use a location other than 'us', e.g.:
     opts = {}
-    if location == 'eu':
+    if location == "eu":
         opts = {"api_endpoint": "eu-documentai.googleapis.com"}
 
     client = documentai.DocumentProcessorServiceClient(opts)

--- a/samples/snippets/process_document_sample_v1beta3.py
+++ b/samples/snippets/process_document_sample_v1beta3.py
@@ -28,10 +28,11 @@ def process_document_sample(
     from google.cloud import documentai_v1beta3 as documentai
 
     # You must set the api_endpoint if you use a location other than 'us', e.g.:
-    # client = documentai.DocumentProcessorServiceClient(
-    #     {"api_endpoint": "eu-documentai.googleapis.com"}
-    # )
-    client = documentai.DocumentProcessorServiceClient()
+    opts = {}
+    if location == 'eu':
+        opts = {"api_endpoint": "eu-documentai.googleapis.com"}
+
+    client = documentai.DocumentProcessorServiceClient(opts)
 
     # The full resource name of the processor, e.g.:
     # projects/project-id/locations/location/processor/processor-id

--- a/samples/snippets/process_document_sample_v1beta3.py
+++ b/samples/snippets/process_document_sample_v1beta3.py
@@ -27,7 +27,10 @@ def process_document_sample(
 ):
     from google.cloud import documentai_v1beta3 as documentai
 
-    # Instantiates a client
+    # You must set the api_endpoint if you use a location other than 'us', e.g.:
+    # client = documentai.DocumentProcessorServiceClient(
+    #     {"api_endpoint": "eu-documentai.googleapis.com"}
+    # )
     client = documentai.DocumentProcessorServiceClient()
 
     # The full resource name of the processor, e.g.:

--- a/samples/snippets/process_document_sample_v1beta3.py
+++ b/samples/snippets/process_document_sample_v1beta3.py
@@ -32,7 +32,7 @@ def process_document_sample(
     if location == "eu":
         opts = {"api_endpoint": "eu-documentai.googleapis.com"}
 
-    client = documentai.DocumentProcessorServiceClient(opts)
+    client = documentai.DocumentProcessorServiceClient(client_options=opts)
 
     # The full resource name of the processor, e.g.:
     # projects/project-id/locations/location/processor/processor-id

--- a/samples/snippets/process_document_sample_v1beta3.py
+++ b/samples/snippets/process_document_sample_v1beta3.py
@@ -29,7 +29,7 @@ def process_document_sample(
 
     # You must set the api_endpoint if you use a location other than 'us', e.g.:
     opts = {}
-    if location == 'eu':
+    if location == "eu":
         opts = {"api_endpoint": "eu-documentai.googleapis.com"}
 
     client = documentai.DocumentProcessorServiceClient(opts)

--- a/samples/snippets/quickstart_sample_v1beta3.py
+++ b/samples/snippets/quickstart_sample_v1beta3.py
@@ -31,7 +31,7 @@ def quickstart(project_id: str, location: str, processor_id: str, file_path: str
     if location == "eu":
         opts = {"api_endpoint": "eu-documentai.googleapis.com"}
 
-    client = documentai.DocumentProcessorServiceClient(opts)
+    client = documentai.DocumentProcessorServiceClient(client_options=opts)
 
     # The full resource name of the processor, e.g.:
     # projects/project-id/locations/location/processor/processor-id

--- a/samples/snippets/quickstart_sample_v1beta3.py
+++ b/samples/snippets/quickstart_sample_v1beta3.py
@@ -28,7 +28,7 @@ def quickstart(project_id: str, location: str, processor_id: str, file_path: str
 
     # You must set the api_endpoint if you use a location other than 'us', e.g.:
     opts = {}
-    if location == 'eu':
+    if location == "eu":
         opts = {"api_endpoint": "eu-documentai.googleapis.com"}
 
     client = documentai.DocumentProcessorServiceClient(opts)

--- a/samples/snippets/quickstart_sample_v1beta3.py
+++ b/samples/snippets/quickstart_sample_v1beta3.py
@@ -25,6 +25,11 @@ from google.cloud import documentai_v1beta3 as documentai
 
 
 def quickstart(project_id: str, location: str, processor_id: str, file_path: str):
+
+    # You must set the api_endpoint if you use a location other than 'us', e.g.:
+    # client = documentai.DocumentProcessorServiceClient(
+    #     {"api_endpoint": "eu-documentai.googleapis.com"}
+    # )
     client = documentai.DocumentProcessorServiceClient()
 
     # The full resource name of the processor, e.g.:

--- a/samples/snippets/quickstart_sample_v1beta3.py
+++ b/samples/snippets/quickstart_sample_v1beta3.py
@@ -27,10 +27,11 @@ from google.cloud import documentai_v1beta3 as documentai
 def quickstart(project_id: str, location: str, processor_id: str, file_path: str):
 
     # You must set the api_endpoint if you use a location other than 'us', e.g.:
-    # client = documentai.DocumentProcessorServiceClient(
-    #     {"api_endpoint": "eu-documentai.googleapis.com"}
-    # )
-    client = documentai.DocumentProcessorServiceClient()
+    opts = {}
+    if location == 'eu':
+        opts = {"api_endpoint": "eu-documentai.googleapis.com"}
+
+    client = documentai.DocumentProcessorServiceClient(opts)
 
     # The full resource name of the processor, e.g.:
     # projects/project-id/locations/location/processor/processor-id


### PR DESCRIPTION
A common issue we're seeing among Document AI customers is that they set the `location` to 'eu' but don't know to change the hostname as well to 'eu-documentai.googleapis.com'.