### PR TITLE
samples: moves import statement within region tags

### DIFF
--- a/samples/snippets/quickstart_sample.py
+++ b/samples/snippets/quickstart_sample.py
@@ -15,7 +15,7 @@
 
 
 # [START documentai_quickstart]
-from google.cloud import documentai_v1 as documentai
+
 
 # TODO(developer): Uncomment these variables before running the sample.
 # project_id= 'YOUR_PROJECT_ID'
@@ -25,6 +25,8 @@ from google.cloud import documentai_v1 as documentai
 
 
 def quickstart(project_id: str, location: str, processor_id: str, file_path: str):
+
+    from google.cloud import documentai_v1 as documentai
 
     # You must set the api_endpoint if you use a location other than 'us', e.g.:
     opts = {}


### PR DESCRIPTION
This is an improvement to the quickstart sample, to make it easier to copy, paste, and run from cloud.google.com.
