### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "documentai",
     "name_pretty": "Cloud Document Understanding API",
     "product_documentation": "https://cloud.google.com/document-understanding/docs/",
-    "client_documentation": "https://googleapis.dev/python/documentai/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/documentai/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.