### PR TITLE
fix: remove libcst from setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setuptools.setup(
         "proto-plus >= 1.10.0",
     ),
     python_requires=">=3.6",
-    setup_requires=["libcst >= 0.2.5"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This library does not depend on `libcst` as it always published with the microgenerator.

Also delete unneeded .tar.gz from the root of the repo. 
