### PR TITLE
test: remove quotes and newlines from output

### DIFF
--- a/samples/snippets/process_document_splitter_sample_test.py
+++ b/samples/snippets/process_document_splitter_sample_test.py
@@ -33,6 +33,9 @@ def test_process_documents(capsys):
     )
     out, _ = capsys.readouterr()
 
+    # Remove newlines and quotes from output for easier comparison
+    out = out.replace(' "" ', " ").replace("\n", "")
+
     expected_strings = [
         "Found 8 subdocuments",
         "confident that pages 1 to 2 are a subdocument",


### PR DESCRIPTION
This test is currently failing with this error:

```
capsys = <_pytest.capture.CaptureFixture object at 0x7f9fb9ed08e0>

    def test_process_documents(capsys):
        process_document_splitter_sample.process_document_splitter_sample(
            project_id=project_id,
            location=location,
            processor_id=processor_id,
            file_path=file_path,
        )
        out, _ = capsys.readouterr()

        expected_strings = [
            "Found 8 subdocuments",
            "confident that pages 1 to 2 are a subdocument",
            "confident that page 10 is a subdocument",
        ]
        for expected_string in expected_strings:
>           assert expected_string in out
E           assert 'confident that pages 1 to 2 are a subdocument' in 'Document processing complete.\n\nFound 8 subdocuments:\n99.7% confident that pages 1 to 2 are a "" subdocument.\n100...." subdocument.\n100.0% confident that page 9 is a "" subdocument.\n99.9% confident that page 10 is a "" subdocument.\n'

process_document_splitter_sample_test.py:42: AssertionError
```
